### PR TITLE
Update krb5-secret.yaml

### DIFF
--- a/stable/control-agent/templates/krb5-secret.yaml
+++ b/stable/control-agent/templates/krb5-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: krb5conf
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "control-agent.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -17,7 +17,7 @@ kind: Secret
 metadata:
  name: kerbsecret
  labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "control-agent.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"


### PR DESCRIPTION
Updated referenced template name to "control-agent.fullname" rather than "fullname" which is not found>