### PR TITLE
Fix identation of control-agent deployment manifest

### DIFF
--- a/stable/control-agent/templates/deployment.yaml
+++ b/stable/control-agent/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
 	  {{- end}}
           {{- if .Values.resources }}
           resources:
-          {{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | indent 12 }}
           {{- end }}
           env:
           - name: HOST
@@ -83,5 +83,5 @@ spec:
       {{- end}}
       {{- if .Values.nodeSelector }}
       nodeSelector:
-      {{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}


### PR DESCRIPTION
These two statements should start from the beginning of the line on order to result in correct indentation.